### PR TITLE
Editing results messaging

### DIFF
--- a/src/components/ResultsList.tsx
+++ b/src/components/ResultsList.tsx
@@ -4,7 +4,7 @@ import Recycler from './Recycler';
 import './ResultsList.css';
 
 export default function ResultsList() {
-  const { recyclerResults } = useContext(RecyclerContext);
+  const { recyclerResults, isInitialLoad } = useContext(RecyclerContext);
 
   // const myStyle = {
   //   backgroundImage: `url(${process.env.PUBLIC_URL + '/mustard-fabric.jpeg'})`,
@@ -14,22 +14,28 @@ export default function ResultsList() {
   // };
 
   return (
-    <div>
-      <div className="results-message-container">
-        <div className="results-message">
-          <h2>You have {recyclerResults.length} matching recyclers. </h2>
-          {recyclerResults.length !== 0 && (
-            <p>Click on the recycler&apos;s cards below to link to each recycler&apos;s website</p>
-          )}
+    <>
+      {!isInitialLoad && (
+        <div>
+          <div className="results-message-container">
+            <div className="results-message">
+              <h2>You have {recyclerResults.length} matching recyclers. </h2>
+              {recyclerResults.length !== 0 && (
+                <p>
+                  Click on the recycler&apos;s cards below to link to each recycler&apos;s website
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="results-container">
+            <div className="results-list">
+              {recyclerResults.length !== 0 &&
+                // tsx error: Property 'data' does not exist on type 'RecyclerResultType[]'.ts(2339)
+                recyclerResults.map((recycler) => <Recycler key={recycler.id} {...recycler} />)}
+            </div>
+          </div>
         </div>
-      </div>
-      <div className="results-container">
-        <div className="results-list">
-          {recyclerResults.length !== 0 &&
-            // tsx error: Property 'data' does not exist on type 'RecyclerResultType[]'.ts(2339)
-            recyclerResults.map((recycler) => <Recycler key={recycler.id} {...recycler} />)}
-        </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 }

--- a/src/context/RecyclerMainPage.tsx
+++ b/src/context/RecyclerMainPage.tsx
@@ -27,6 +27,8 @@ export interface SecondaryMaterialOptionType {
 type RecyclerContextType = {
   recyclerResults: RecyclerResultType[];
   setRecyclerResults: Dispatch<SetStateAction<RecyclerResultType[]>>;
+  isInitialLoad: boolean;
+  setIsInitialLoad: Dispatch<SetStateAction<boolean>>;
   isLoading: boolean;
   setIsLoading: Dispatch<SetStateAction<boolean>>;
   error: string;
@@ -63,6 +65,8 @@ const baseContext: RecyclerContextType = {
   setRecyclerResults: () => null,
   isLoading: true,
   setIsLoading: () => true,
+  isInitialLoad: true,
+  setIsInitialLoad: () => true,
   error: '',
   setError: () => '',
   primaryMaterialFilterOptions: [],
@@ -94,6 +98,7 @@ export const RecyclerContext = createContext<RecyclerContextType>(baseContext);
 
 const RecyclerMainPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
   const [error, setError] = useState<string>('');
   const [recyclerResults, setRecyclerResults] = useState<RecyclerResultType[]>([]);
   // to do step 1: add state for material types to map through in MaterialFilter input selects
@@ -176,6 +181,7 @@ const RecyclerMainPage: React.FC = () => {
   const onSubmitFilterForm = () => {
     storeUserSelection();
     fetchMatchingRecyclers();
+    setIsInitialLoad(false);
   };
 
   return (
@@ -184,6 +190,8 @@ const RecyclerMainPage: React.FC = () => {
         value={{
           recyclerResults,
           setRecyclerResults,
+          isInitialLoad,
+          setIsInitialLoad,
           isLoading,
           setIsLoading,
           error,


### PR DESCRIPTION
## Description
<!-- What does this code **change**? Why did you choose this approach? Did you learn anything worth sharing? -->
As an addition to the last PR where the list only loads after the form is filled out, I made some adjustments so that the results message only displays AFTER the first initial page load. 

## Related Issue
<!-- Write "closes" followed by the Github issue number – this will automatically close the issue when the PR merges -->
closes 31

## Updates
<!-- Include screenshots or videos with descriptions of the UI before and after your changes. -->

### Before

<img width="839" alt="image" src="https://github.com/recycler-connect/recyclers/assets/104444969/ef89fa66-b6de-43a0-b3c2-2b1f98f98bb0">

### After
<img width="820" alt="image" src="https://github.com/recycler-connect/recyclers/assets/104444969/05180b5c-2df7-4577-ad57-a51625d1249c">

## Acceptance Criteria
<!-- Include AC from the Github issue -->
- [x]  Results message displays only AFTER user submits form

## Testing Steps / QA Criteria
<!-- Provide steps to follow to properly test your additions. -->

1.  Open web app and inspect page. Results message should not display.
2. Fill out form and inspect page. Results message should display along with any matching recyclers.